### PR TITLE
CRUD for storing the program schedules information.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -13,6 +13,7 @@
         <commons-codec.version>1.6</commons-codec.version>
         <config.version>0.4.0</config.version>
         <dispatch.version>0.11.2</dispatch.version>
+        <h2-connector.version>1.3.176</h2-connector.version>
         <jetty.version>7.6.3.v20120416</jetty.version>
         <jetty-webapp.version>8.1.7.v20120910</jetty-webapp.version>
         <jetty-maven-plugin.version>8.1.5.v20120716</jetty-maven-plugin.version>
@@ -51,6 +52,11 @@
             <groupId>com.typesafe</groupId>
             <artifactId>config</artifactId>
             <version>${config.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.h2database</groupId>
+            <artifactId>h2</artifactId>
+            <version>${h2-connector.version}</version>
         </dependency>
         <dependency>
             <groupId>javax.servlet</groupId>

--- a/src/main/scala/org/tinydvr/config/Configuration.scala
+++ b/src/main/scala/org/tinydvr/config/Configuration.scala
@@ -2,5 +2,9 @@ package org.tinydvr.config
 
 abstract class Configuration {
 
-  def schedulesDirectCredientials: SchedulesDirectCredentials
+  // The database connection information
+  def databaseInfo: DatabaseConnectionInfo
+
+  // Authentication credentials for schedules direct.
+  def schedulesDirectCredentials: SchedulesDirectCredentials
 }

--- a/src/main/scala/org/tinydvr/config/ConfigurationLoader.scala
+++ b/src/main/scala/org/tinydvr/config/ConfigurationLoader.scala
@@ -4,7 +4,7 @@ import com.typesafe.config.ConfigFactory
 
 object ConfigurationLoader {
 
-  private val CONFIG_FILE_PROPERTY = "tinydvr.user.configuration.file"
+  private val CONFIG_FILE_PROPERTY = "tinydvr.configuration.file"
   private val CONFIG_FILE_DEFAULT = "/etc/tinydvr/tinydvr.conf"
 
   def load(): Configuration =  new Configuration {
@@ -15,8 +15,18 @@ object ConfigurationLoader {
     private val configurationFile = Option(System.getProperty(CONFIG_FILE_PROPERTY)).getOrElse(CONFIG_FILE_DEFAULT)
     private val factory = ConfigFactory.load(configurationFile)
 
-    // Authentication credientials for schedules direct.
-    def schedulesDirectCredientials: SchedulesDirectCredentials = {
+    // The database connection information
+    def databaseInfo: DatabaseConnectionInfo = {
+      val db = factory.getConfig("db")
+      DatabaseConnectionInfo(
+        db.getString("url"),
+        db.getString("username"),
+        db.getString("password")
+      )
+    }
+
+    // Authentication credentials for schedules direct.
+    def schedulesDirectCredentials: SchedulesDirectCredentials = {
       val sd = factory.getConfig("schedules_direct")
       SchedulesDirectCredentials(
         sd.getString("username"),

--- a/src/main/scala/org/tinydvr/config/ConfigurationTypes.scala
+++ b/src/main/scala/org/tinydvr/config/ConfigurationTypes.scala
@@ -1,3 +1,22 @@
 package org.tinydvr.config
 
+import java.sql.{Connection, DriverManager}
+import org.squeryl.adapters.H2Adapter
+import org.squeryl.internals.DatabaseAdapter
+
+case class DatabaseConnectionInfo(url: String, username: String, password: String) {
+  private val H2DB_REGEX = """^jdbc:h2:.*""".r
+
+  def getAdapter: DatabaseAdapter = {
+    url match {
+      case H2DB_REGEX() => new H2Adapter
+      case _ => throw new IllegalArgumentException("Could not create adapter for url \"" + url + "\"")
+    }
+  }
+
+  def getConnection: Connection= {
+    DriverManager.getConnection(url, username, password)
+  }
+}
+
 case class SchedulesDirectCredentials(username: String, password: String)

--- a/src/main/scala/org/tinydvr/db/Lineup.scala
+++ b/src/main/scala/org/tinydvr/db/Lineup.scala
@@ -1,0 +1,48 @@
+package org.tinydvr.db
+
+import org.squeryl.KeyedEntity
+import org.squeryl.annotations._
+import org.joda.time.DateTime
+import org.tinydvr.schedulesdirect.api.GetLineupResponse
+
+class Lineup extends KeyedEntity[Long] {
+
+  @Column(name = "id")
+  var id: Long = _
+
+  @Column(name = "uri", length = 255)
+  var uri: String = _
+
+  //
+  // The epoch for the last time that this lineup was updated
+  //
+  @Column(name = "last_updated")
+  var lastUpdatedEpoch: Long = _
+
+  //
+  // The json returned from schedules direct.
+  //
+  @Column(name = "lineup_json")
+  var lineupJson: String = _
+
+  //
+  // Convenience functions for accessing the fields
+  //
+
+  def lastUpdated: DateTime = {
+    new DateTime(lastUpdatedEpoch)
+  }
+
+  def lastUpdated_=(dt: DateTime): Unit = {
+    lastUpdatedEpoch = dt.getMillis
+  }
+
+  def lineup: GetLineupResponse = {
+    TinyDVRDB.fromJson[GetLineupResponse](lineupJson)
+  }
+
+  def lineup_=(r: GetLineupResponse): Unit = {
+    lineupJson = TinyDVRDB.toJson(r)
+  }
+
+}

--- a/src/main/scala/org/tinydvr/db/Program.scala
+++ b/src/main/scala/org/tinydvr/db/Program.scala
@@ -1,0 +1,43 @@
+package org.tinydvr.db
+
+import org.squeryl.KeyedEntity
+import org.squeryl.annotations._
+import org.joda.time.DateTime
+import org.tinydvr.service.api.{Program => ProgramDTO}
+
+class Program extends KeyedEntity[String] {
+
+  @Column(name = "id")
+  var id: String = _
+
+  //
+  // The epoch for the last time that this lineup was updated
+  //
+  @Column(name = "last_updated_epoch")
+  var lastUpdatedEpoch: Long = System.currentTimeMillis
+
+  //
+  // The json returned from schedules direct.
+  //
+  @Column(name = "program_json")
+  var programJson: String = _
+
+  //
+  // Convenience functions for accessing the fields
+  //
+
+  def lastUpdated: DateTime = {
+    new DateTime(lastUpdatedEpoch)
+  }
+
+  def lastUpdated_=(dt: DateTime): Unit = {
+    lastUpdatedEpoch = dt.getMillis
+  }
+
+  def program: ProgramDTO = TinyDVRDB.fromJson[ProgramDTO](programJson)
+
+  def lineup_=(r: ProgramDTO): Unit = {
+    programJson = TinyDVRDB.toJson(r)
+  }
+
+}

--- a/src/main/scala/org/tinydvr/db/Schedule.scala
+++ b/src/main/scala/org/tinydvr/db/Schedule.scala
@@ -1,0 +1,33 @@
+package org.tinydvr.db
+
+import org.squeryl.KeyedEntity
+import org.squeryl.PrimitiveTypeMode._
+import org.squeryl.annotations._
+import org.squeryl.dsl.CompositeKey4
+
+class Schedule extends KeyedEntity[CompositeKey4[Long, String, String, Long]] {
+
+  def id: CompositeKey4[Long, String, String, Long] = compositeKey(lineupId, stationId, programId, airDateTimeEpoch)
+
+  @Column(name = "lineup_id")
+  var lineupId: Long = _
+
+  @Column(name = "station_id")
+  var stationId: String = _
+
+  @Column(name = "program_id")
+  var programId: String = _
+
+  // The program title is stored outside the json for searching
+  @Column(name = "program_title", length = 255)
+  var programTitle: String = _
+
+  @Column(name = "air_date_time_epoch")
+  var airDateTimeEpoch: Long = _
+
+  @Column(name = "duration_in_seconds")
+  var durationInSeconds: Int = _
+
+  @Column(name = "is_new")
+  var isNew: Boolean = _
+}

--- a/src/main/scala/org/tinydvr/db/TinyDVRDB.scala
+++ b/src/main/scala/org/tinydvr/db/TinyDVRDB.scala
@@ -1,0 +1,255 @@
+package org.tinydvr.db
+
+import net.liftweb.json.Extraction._
+import net.liftweb.json._
+import org.squeryl.PrimitiveTypeMode._
+import org.squeryl.Schema
+import org.tinydvr.config.DatabaseConnectionInfo
+import org.tinydvr.schedulesdirect.api.{GetLineupResponse, LocalDateSerializer, DateTimeSerializer}
+import org.tinydvr.util.DatabaseConnection
+import org.joda.time.DateTime
+
+object TinyDVRDB extends Schema {
+
+  //
+  // Tables
+  //
+
+  val lineups = table[Lineup]("lineups")
+  val programs = table[Program]("programs")
+  val schedules = table[Schedule]("schedules")
+
+  //
+  // Table constraints
+  //
+
+  on(lineups)(l => declare(
+    l.id is (autoIncremented),
+    l.uri is (indexed),
+    l.uri is (unique),
+    l.lineupJson is (dbType("text"))
+  ))
+
+  on(programs)(p => declare(
+    p.id is (indexed),
+    p.programJson is (dbType("text"))
+  ))
+
+  on(schedules)(s => declare(
+    columns(s.lineupId, s.stationId, s.programId, s.airDateTimeEpoch) are (unique),
+    columns(s.lineupId, s.airDateTimeEpoch) are (indexed),
+    columns(s.lineupId, s.stationId) are (indexed),
+    columns(s.lineupId, s.programTitle) are (indexed)
+  ))
+
+  //
+  // Some useful constants and helpers
+  //
+
+  val schedulesDirectFormats =
+    DefaultFormats +
+      new DateTimeSerializer +
+      new LocalDateSerializer
+
+  def fromJson[T](is: String)(implicit mf: scala.reflect.Manifest[T]): T = {
+    implicit val formats = schedulesDirectFormats
+    JsonParser.parse(is).extract[T]
+  }
+
+  def toJson[T](t: T): String = {
+    implicit val formats = schedulesDirectFormats
+    compact(render(decompose(t)))
+  }
+}
+
+trait TinyDVRDB {
+  def dbInfo: DatabaseConnectionInfo
+
+  lazy val tinyDvrDb = new TinyDVRDBAPI(dbInfo)
+}
+
+class TinyDVRDBAPI(db: DatabaseConnectionInfo) extends DatabaseConnection(db) {
+
+  import TinyDVRDB._
+
+  //
+  // Lineup Management
+  //
+
+  def getAllLineups(): List[Lineup] = {
+    run {
+      from(lineups)(l => select(l)).toList
+    }
+  }
+
+  def getLineup(uri: String): Option[Lineup] = {
+    run {
+      from(lineups)(l => {
+        where(l.uri === uri).select(l)
+      }).headOption
+    }
+  }
+
+  /**
+   * Inserts or updates the provided lineup information.
+   * @param uri     The unique uri of the lineup for schedules direct.
+   * @param lineup  The lineup data returned by schedules direct
+   * @return        The lineup id
+   */
+  def insertOrUpdateLineup(uri: String, lineup: GetLineupResponse): Long = {
+    run {
+      val existing = getLineup(uri)
+      val record = existing.getOrElse {
+        val l = new Lineup
+        l.uri = uri
+        l
+      }
+      record.lastUpdated = new DateTime
+      record.lineup = lineup
+      if (existing.isDefined) {
+        lineups.update(record)
+      } else {
+        lineups.insert(record)
+      }
+      record.id
+    }
+  }
+
+  //
+  // Program Management
+  //
+
+  /**
+   * Inserts new programs into the data base.
+   */
+  def insertPrograms(ps: Iterable[Program]): Unit = {
+    run {
+      inTransaction {
+        programs.insert(ps)
+      }
+    }
+  }
+
+  /**
+   * Returns all program ids currently in the database.
+   * Note that schedules direct requires applications to cache programs to avoid hammering their servers.
+   * @return   All of the program ids currently in the database
+   */
+  def getAllProgramIds(): Set[String] = {
+    run {
+      from(programs)(p => select(p.id)).toSet
+    }
+  }
+
+  /**
+   * Erases programs that haven't been seen since the provided date time.
+   * Note: You should be liberal here. If you purge too many programs, the next update will
+   * hammer schedules direct and they will hate you.
+   * @param dt  The datetime for which programs not updated since will be deleted.
+   */
+  def purgeProgramsNotSeenSince(dt: DateTime): Unit = {
+    val epoch = dt.getMillis
+    run {
+      inTransaction {
+        programs.deleteWhere(_.lastUpdatedEpoch lt epoch)
+      }
+    }
+  }
+
+  /**
+   * Sets the last updated field of the provided ids to the current system time.
+   * This should be run for cached program ids.
+   */
+  def touchPrograms(programIds: Set[String]): Unit = {
+    val epoch = System.currentTimeMillis
+    run {
+      inTransaction {
+        update(programs)(p => {
+          where(p.id in programIds).
+            set(p.lastUpdatedEpoch := epoch)
+        })
+      }
+    }
+  }
+
+  //
+  // Schedules Management
+  //
+
+  /**
+   * Deletes schedules for programs that air before the provided datetime.
+   * Note: give youself some wiggle room here: A program may start at 11pm on Monday
+   * and not end until 3am on Tuesday.
+   * Deletion is done based on airdatetime since it is indexed in the database.
+   * @return  The number of rows erased.
+   */
+  def eraseSchedulesAiringBefore(lineupId: Long, dateTime: DateTime): Int = {
+    val epoch = dateTime.getMillis
+    run {
+      inTransaction {
+        schedules.deleteWhere(s => {
+          (s.lineupId === lineupId) and
+            (s.airDateTimeEpoch lt epoch)
+        })
+      }
+    }
+  }
+
+  /**
+   * Queries for listings between the provided date times for the provided station ids.
+   * The query handles border cases:
+   * A program that starts before the startTime but ends in the range will be returned.
+   * Similarly, a program that ends after endTime but starts in the range will be returned.
+   * This query should be relatively fast for short times (a few hours) or a single station.
+   */
+  def findScheduledPrograms(lineupId: Long, start: DateTime, end: DateTime): List[(Schedule, Program)] = {
+    val startEpoch = start.getMillis
+    val endEpoch = end.getMillis
+    run {
+      join(schedules, programs)((s, p) => {
+        where(
+          (s.lineupId === lineupId) and
+            (s.airDateTimeEpoch lte endEpoch) and
+            ((s.airDateTimeEpoch + s.durationInSeconds * 1000L) gte startEpoch)
+        ).select((s, p)).on(s.programId === p.id)
+      }).toList
+    }
+  }
+
+  /**
+   * Queries for listings containing the provided text.
+   */
+  def findScheduledPrograms(lineupId: Long, query: String): List[(Schedule, Program)] = {
+    run {
+      join(schedules, programs)((s, p) => {
+        where(
+          (s.lineupId === lineupId) and
+            (s.programTitle like query)
+        ).select((s, p)).on(s.programId === p.id)
+      }).toList
+    }
+  }
+
+  /**
+   * Queries for listings for the provided station id.
+   */
+  def findScheduledProgramsForStation(lineupId: Long, stationId: String): List[(Schedule, Program)] = {
+    run {
+      join(schedules, programs)((s, p) => {
+        where(
+          (s.lineupId === lineupId) and
+            (s.programId === stationId)
+        ).select((s, p)).on(s.programId === p.id)
+      }).toList
+    }
+  }
+
+  def insertSchedules(s: Iterable[Schedule]): Unit = {
+    run {
+      inTransaction {
+        schedules.insert(s)
+      }
+    }
+  }
+
+}

--- a/src/main/scala/org/tinydvr/service/api/APITypes.scala
+++ b/src/main/scala/org/tinydvr/service/api/APITypes.scala
@@ -1,0 +1,40 @@
+package org.tinydvr.service.api
+
+import org.joda.time._
+
+/**
+ * The types served by the core api for tinydvr.
+ * Many of these are also used as DTOs or serialized in the database.
+ */
+
+case class Program(programID: String, // the program id provided by schedules direct
+                   title: String,
+                   castInfo: List[ProgramPerson],
+                   description: Option[String],
+                   episodeTitle: Option[String],
+                   episode: Option[Int],
+                   genres: List[String],
+                   movieInfo: Option[MovieInfo],
+                   originalAirDate: Option[LocalDate],
+                   season: Option[Int],
+                   showType: Option[String])
+
+case class ScheduledProgram(program: Program,
+                            stationID: String, // the station ID provided by schedules direct.
+                            start: DateTimeDTO,
+                            end: DateTimeDTO,
+                            durationInSeconds: Int)
+
+case class DateTimeDTO(epoch: Long,
+                       dateTime: DateTime,
+                       date: LocalDate,
+                       time: LocalTime)
+
+case class ProgramPerson(personId: String, // id provided by schedules direct
+                         name: String,
+                         role: String,
+                         characterName: Option[String],
+                         billingOrder: Int)
+
+case class MovieInfo(year: Int,
+                     duration: Option[Int])

--- a/src/main/scala/org/tinydvr/util/DatabaseConnection.scala
+++ b/src/main/scala/org/tinydvr/util/DatabaseConnection.scala
@@ -1,0 +1,28 @@
+package org.tinydvr.util
+
+import org.squeryl.Session
+import org.squeryl.PrimitiveTypeMode._
+import org.tinydvr.config.DatabaseConnectionInfo
+import org.slf4j.LoggerFactory
+
+abstract class DatabaseConnection(db: DatabaseConnectionInfo) {
+
+  private val logger = LoggerFactory.getLogger(getClass)
+
+  protected def run[A](a: => A): A = {
+    if (Session.hasCurrentSession) {
+      a
+    } else {
+      val session = Session.create(db.getConnection, db.getAdapter)
+      try {
+        transaction(session)(a)
+      } finally {
+        try {
+          session.cleanup
+        } catch {
+          case e: Exception => logger.error("Unable to cleanup Squeryl session", e)
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
The database serves as a thin index over either the api dtos or the data returned from schedules direct.
This is achieved by storing the dtos as json.
We may want to re-evaluate this strategy if the database grows too large.

All of this is untested at the moment.